### PR TITLE
Add package.json file to permit installation from npm CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "plain-scrollbar",
+  "description": "a simple custom scrollbar",
+  "author": "Kay Schewe <www.kayschewe.de>",
+  "homepage": "https://github.com/ewya/PlainScrollbar",
+  "license": "MIT",
+  "dependencies": {
+  },
+  "main": "plain-scrollbar.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ewya/PlainScrollbar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ewya/PlainScrollbar/issues"
+  }
+}


### PR DESCRIPTION
Even if package is not published to npm, having a `package.json` file could permit installation using npm CLI (i.e. by running `npm install https://github.com/ewya/PlainScrollbar.git`).
Installing the package this way would prevent having to bundling the full source code it in other applications repository.